### PR TITLE
module reload: allow to unload and reload the module

### DIFF
--- a/ap1302.c
+++ b/ap1302.c
@@ -2078,7 +2078,7 @@ static void ap1302_sensor_cleanup(struct ap1302_sensor *sensor)
 	if (sensor->num_supplies)
 		regulator_bulk_free(sensor->num_supplies, sensor->supplies);
 
-	put_device(sensor->dev);
+	device_unregister(sensor->dev);
 	of_node_put(sensor->of_node);
 }
 


### PR DESCRIPTION
Fixing "kobject_add_internal failed for 4-003c-ar1335.0 with -EEXIST"