### PR TITLE
[5.15] Support for dynamic sensor select, support for SIP override

### DIFF
--- a/kmod/ap1302.c
+++ b/kmod/ap1302.c
@@ -2220,12 +2220,12 @@ static void ap1302_ctrls_cleanup(struct ap1302_device *ap1302)
 
 static struct v4l2_mbus_framefmt *
 ap1302_get_pad_format(struct ap1302_device *ap1302,
-		      struct v4l2_subdev_pad_config *cfg,
+		      struct v4l2_subdev_state *sd_state,
 		      unsigned int pad, u32 which)
 {
 	switch (which) {
 	case V4L2_SUBDEV_FORMAT_TRY:
-		return v4l2_subdev_get_try_format(&ap1302->sd, cfg, pad);
+		return v4l2_subdev_get_try_format(&ap1302->sd, sd_state, pad);
 	case V4L2_SUBDEV_FORMAT_ACTIVE:
 		return &ap1302->formats[pad].format;
 	default:
@@ -2234,16 +2234,16 @@ ap1302_get_pad_format(struct ap1302_device *ap1302,
 }
 
 static int ap1302_init_cfg(struct v4l2_subdev *sd,
-			   struct v4l2_subdev_pad_config *cfg)
+			   struct v4l2_subdev_state *sd_state)
 {
-	u32 which = cfg ? V4L2_SUBDEV_FORMAT_TRY : V4L2_SUBDEV_FORMAT_ACTIVE;
+	u32 which = sd_state ? V4L2_SUBDEV_FORMAT_TRY : V4L2_SUBDEV_FORMAT_ACTIVE;
 	struct ap1302_device *ap1302 = to_ap1302(sd);
 	const struct ap1302_sensor_info *info = &ap1302->sensor_info;
 	unsigned int pad;
 
 	for (pad = 0; pad < ARRAY_SIZE(ap1302->formats); ++pad) {
 		struct v4l2_mbus_framefmt *format =
-			ap1302_get_pad_format(ap1302, cfg, pad, which);
+			ap1302_get_pad_format(ap1302, sd_state, pad, which);
 
 		format->width = info->resolution.width;
 		format->height = info->resolution.height;
@@ -2267,7 +2267,7 @@ static int ap1302_init_cfg(struct v4l2_subdev *sd,
 }
 
 static int ap1302_enum_mbus_code(struct v4l2_subdev *sd,
-				 struct v4l2_subdev_pad_config *cfg,
+				 struct v4l2_subdev_state *sd_state,
 				 struct v4l2_subdev_mbus_code_enum *code)
 {
 	struct ap1302_device *ap1302 = to_ap1302(sd);
@@ -2293,7 +2293,7 @@ static int ap1302_enum_mbus_code(struct v4l2_subdev *sd,
 }
 
 static int ap1302_enum_frame_size(struct v4l2_subdev *sd,
-				  struct v4l2_subdev_pad_config *cfg,
+				  struct v4l2_subdev_state *sd_state,
 				  struct v4l2_subdev_frame_size_enum *fse)
 {
 	struct ap1302_device *ap1302 = to_ap1302(sd);
@@ -2337,13 +2337,13 @@ static int ap1302_enum_frame_size(struct v4l2_subdev *sd,
 }
 
 static int ap1302_get_fmt(struct v4l2_subdev *sd,
-			  struct v4l2_subdev_pad_config *cfg,
+			  struct v4l2_subdev_state *sd_state,
 			  struct v4l2_subdev_format *fmt)
 {
 	struct ap1302_device *ap1302 = to_ap1302(sd);
 	const struct v4l2_mbus_framefmt *format;
 
-	format = ap1302_get_pad_format(ap1302, cfg, fmt->pad, fmt->which);
+	format = ap1302_get_pad_format(ap1302, sd_state, fmt->pad, fmt->which);
 
 	mutex_lock(&ap1302->lock);
 	fmt->format = *format;
@@ -2353,7 +2353,7 @@ static int ap1302_get_fmt(struct v4l2_subdev *sd,
 }
 
 static int ap1302_set_fmt(struct v4l2_subdev *sd,
-			  struct v4l2_subdev_pad_config *cfg,
+			  struct v4l2_subdev_state *sd_state,
 			  struct v4l2_subdev_format *fmt)
 {
 	struct ap1302_device *ap1302 = to_ap1302(sd);
@@ -2364,9 +2364,9 @@ static int ap1302_set_fmt(struct v4l2_subdev *sd,
 
 	/* Formats on the sink pads can't be changed. */
 	if (fmt->pad < AP1302_PAD_SOURCE_VC0)
-		return ap1302_get_fmt(sd, cfg, fmt);
+		return ap1302_get_fmt(sd, sd_state, fmt);
 
-	format = ap1302_get_pad_format(ap1302, cfg, fmt->pad, fmt->which);
+	format = ap1302_get_pad_format(ap1302, sd_state, fmt->pad, fmt->which);
 
 	/* Validate the media bus code, default to the first supported value. */
 	for (i = 0; i < ARRAY_SIZE(supported_video_formats); i++) {
@@ -2409,7 +2409,7 @@ static int ap1302_set_fmt(struct v4l2_subdev *sd,
 }
 
 static int ap1302_get_selection(struct v4l2_subdev *sd,
-				struct v4l2_subdev_pad_config *cfg,
+				struct v4l2_subdev_state *sd_state,
 				struct v4l2_subdev_selection *sel)
 {
 	struct ap1302_device *ap1302 = to_ap1302(sd);
@@ -2748,7 +2748,7 @@ static const struct v4l2_subdev_internal_ops ap1302_subdev_internal_ops = {
  */
 
 static int ap1302_sensor_enum_mbus_code(struct v4l2_subdev *sd,
-					struct v4l2_subdev_pad_config *cfg,
+					struct v4l2_subdev_state *sd_state,
 					struct v4l2_subdev_mbus_code_enum *code)
 {
 	struct ap1302_sensor *sensor = to_ap1302_sensor(sd);
@@ -2762,7 +2762,7 @@ static int ap1302_sensor_enum_mbus_code(struct v4l2_subdev *sd,
 }
 
 static int ap1302_sensor_enum_frame_size(struct v4l2_subdev *sd,
-					 struct v4l2_subdev_pad_config *cfg,
+					 struct v4l2_subdev_state *sd_state,
 					 struct v4l2_subdev_frame_size_enum *fse)
 {
 	struct ap1302_sensor *sensor = to_ap1302_sensor(sd);
@@ -2783,7 +2783,7 @@ static int ap1302_sensor_enum_frame_size(struct v4l2_subdev *sd,
 }
 
 static int ap1302_sensor_get_fmt(struct v4l2_subdev *sd,
-				 struct v4l2_subdev_pad_config *cfg,
+				 struct v4l2_subdev_state *sd_state,
 				 struct v4l2_subdev_format *fmt)
 {
 	struct ap1302_sensor *sensor = to_ap1302_sensor(sd);
@@ -3317,7 +3317,6 @@ static int ap1302_load_firmware(struct ap1302_device *ap1302)
 
 	}
 #endif
-
 		return ret;
 	}
 


### PR DESCRIPTION
Driver updates:
- use of default OnSemi firmware, no configuration change for stereo mode
- driver will configure the AP1302 for stereo mode
- Using firmware 433 with SIP config removed. Functional with firmware 434 tested with SIP config present.
- support for Primary, Secondary and Stereo streaming

Device tree has changed, check yaml file.

Known SIP configuration:
- AR0144:
  - Dual I2C, Alt Address : 0x3330, 0x3730
  - Dual I2C : 0x3320, 0x3720
  - Single I2C: 0x3320, 0x3330
- AR1335:
  - Dual I2C: 0xF36C, 0x376C
  - Single I2C: 0xF36C, 0x336C ( actuator SIP not changed by driver which may cause issue )
- AR0830:
  - Dual I2C: 0xF36C, 0x376C
